### PR TITLE
Add Cloze Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A prototype for practicing coding using [cloze deletion](https://en.wikipedia.or
 Experience it yourself here: [Code Cloze Demo](https://chan-w.github.io/code-cloze-demo-gh-pages/)
 
 ## Creating Clozes
-- Clozes are created as `{{group_id::hidden_text}}`, where group_id is a string.
-    - Please limit cloze deletions to one line as multiline cloze deletions seem to break the editor.
+- Cloze deletions are created as `{{group_id::hidden_text}}`, where group_id is a string.
+    - Please limit the length of a single cloze deletion to 1 line. Instead of multiline cloze deletions, create a cloze deletion on each line with the same `group_id`. 
 - Hidden clozes are displayed to the user as `[... group_id ...]`. 
 - When the user reveals a cloze, all clozes with the same group_id are revealed.
-- For examples, see https://github.com/chan-w/code-cloze/blob/48e25a3db9e7c03bc0e738bcc9a7a5ea642dcfe6/src/binary-search-examples.ts#L6
+- For examples, see https://github.com/chan-w/code-cloze/blob/85c2afd482bb5b6c621a9eb7b3695dcc2492d310/src/binary-search-examples.ts#L6
 
 
 ## Development
@@ -17,7 +17,7 @@ This project uses CodeMirror 6, Vite.js, and TypeScript.
 ### Overview
 - `src/cloze-editor.ts`: Implementation of CodeMirror plugin for cloze functionality
 - `src/binary-search-examples.ts`: Example usages of CodeMirror plugin
-    - https://github.com/chan-w/code-cloze/blob/48e25a3db9e7c03bc0e738bcc9a7a5ea642dcfe6/src/binary-search-examples.ts#L6
+    - https://github.com/chan-w/code-cloze/blob/85c2afd482bb5b6c621a9eb7b3695dcc2492d310/src/binary-search-examples.ts#L6
 - `src/large-file-example.ts`: Example with a larger file
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ A prototype for practicing coding using [cloze deletion](https://en.wikipedia.or
 
 Experience it yourself here: [Code Cloze Demo](https://chan-w.github.io/code-cloze-demo-gh-pages/)
 
+## Creating Clozes
+- Clozes are created as `{{group_id::hidden_text}}`, where group_id is a string.
+    - Please limit cloze deletions to one line as multiline cloze deletions seem to break the editor.
+- Hidden clozes are displayed to the user as `[... group_id ...]`. 
+- When the user reveals a cloze, all clozes with the same group_id are revealed.
+- For examples, see https://github.com/chan-w/code-cloze/blob/48e25a3db9e7c03bc0e738bcc9a7a5ea642dcfe6/src/binary-search-examples.ts#L6
+
+
 ## Development
 This project uses CodeMirror 6, Vite.js, and TypeScript.
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,13 @@
     <title>Code Cloze Examples</title>
   </head>
   <body>
-    <h1 id="bsearch-examples">Binary Search Examples</h1>
+    <!--div id="underline"></div>
+    <script type="module" src="/src/underline-editor.ts"></script-->
+
+    <div id="js-demo-1"></div>
+    <script type="module" src="/src/cloze-editor.ts"></script>
+
+    <!--h1 id="bsearch-examples">Binary Search Examples</h1>
     <p>Click on each cloze ([...]) to switch between revealed and hidden</p>
     <h2>First</h2>
     <div id="bsearch-first"></div>
@@ -15,12 +21,11 @@
     <div id="bsearch-last"></div>
     <h2>Any</h2>
     <div id="bsearch-any"></div>
-    <script type="module" src="/src/cloze-editor.ts"></script>
     <script type="module" src="/src/binary-search-examples.ts"></script>
 
     <h1 id="large-file-example">Large File Example</h1>
     How does this look on mobile or desktop?
     <div id="youtube-dl-aes-py-large-file-demo"></div>
-    <script type="module" src="/src/large-file-example.ts"></script>
+    <script type="module" src="/src/large-file-example.ts"></script-->
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,22 +10,22 @@
     <!--div id="underline"></div>
     <script type="module" src="/src/underline-editor.ts"></script-->
 
-    <div id="js-demo-1"></div>
+    <!-- div id="js-demo-1"></div -->
     <script type="module" src="/src/cloze-editor.ts"></script>
 
-    <!--h1 id="bsearch-examples">Binary Search Examples</h1>
-    <p>Click on each cloze ([...]) to switch between revealed and hidden</p>
+    <h1 id="bsearch-examples">Binary Search Examples</h1>
+    <script type="module" src="/src/binary-search-examples.ts"></script>
+    <p>Click on each cloze ([... id ...]) to switch between revealed and hidden.</p>
     <h2>First</h2>
     <div id="bsearch-first"></div>
     <h2>Last</h2>
     <div id="bsearch-last"></div>
     <h2>Any</h2>
     <div id="bsearch-any"></div>
-    <script type="module" src="/src/binary-search-examples.ts"></script>
 
     <h1 id="large-file-example">Large File Example</h1>
     How does this look on mobile or desktop?
     <div id="youtube-dl-aes-py-large-file-demo"></div>
-    <script type="module" src="/src/large-file-example.ts"></script-->
+    <script type="module" src="/src/large-file-example.ts"></script>
   </body>
 </html>

--- a/src/binary-search-examples.ts
+++ b/src/binary-search-examples.ts
@@ -11,8 +11,8 @@ new EditorView({
     while left <= right:
         mid = (left + right) // 2
         if target == arr[mid]:
-            {{result = mid}}
-            {{break}}
+            {{m::result = mid}}
+            {{m::break}}
         elif target < arr[mid]:
             {{right = mid - 1}}
         else:

--- a/src/binary-search-examples.ts
+++ b/src/binary-search-examples.ts
@@ -1,7 +1,7 @@
 import { basicSetup } from "codemirror";
 import { EditorView } from "@codemirror/view"
 import { python } from '@codemirror/lang-python';
-import clozePlugin  from './cloze-editor';
+import { clozePlugin }  from './cloze-editor';
 
 new EditorView({
     doc: `def search_any(arr, target):
@@ -11,12 +11,12 @@ new EditorView({
     while left <= right:
         mid = (left + right) // 2
         if target == arr[mid]:
-            {{m::result = mid}}
-            {{m::break}}
+            {{a1::result = mid}}
+            {{a1::break}}
         elif target < arr[mid]:
-            {{right = mid - 1}}
+            {{a2::right = mid - 1}}
         else:
-            {{left = mid + 1}}
+            {{a3::left = mid + 1}}
     return result
     `,
     extensions: [basicSetup, clozePlugin, python(), EditorView.editable.of(false), EditorView.lineWrapping],
@@ -31,12 +31,12 @@ new EditorView({
     while left <= right:
         mid = (left + right) // 2
         if target == arr[mid]:
-            {{result = mid}}
-            {{right = mid - 1}}
+            {{a1::result = mid}}
+            {{a1::right = mid - 1}}
         elif target < arr[mid]:
-            {{right = mid - 1}}
+            {{a2::right = mid - 1}}
         else:
-            {{left = mid + 1}}
+            {{a3::left = mid + 1}}
     return result
     `,
     extensions: [basicSetup, clozePlugin, python(), EditorView.editable.of(false), EditorView.lineWrapping],
@@ -51,12 +51,12 @@ new EditorView({
     while left <= right:
         mid = (left + right) // 2
         if target == arr[mid]:
-            {{result = mid}}
-            {{left = mid + 1}}
+            {{a1::result = mid}}
+            {{a1::left = mid + 1}}
         elif target < arr[mid]:
-            {{right = mid - 1}}
+            {{a2::right = mid - 1}}
         else:
-            {{left = mid + 1}}
+            {{a3::left = mid + 1}}
     return result
     `,
     extensions: [basicSetup, clozePlugin, python(), EditorView.editable.of(false), EditorView.lineWrapping],

--- a/src/cloze-editor.ts
+++ b/src/cloze-editor.ts
@@ -46,7 +46,7 @@ class ClozeGroupCollection {
 interface DecorationSetMap extends DecorationSet {
   clozeStateMap: Map<string, boolean>;
 }
-const revealedClozeGroups = StateField.define<DecorationSetMap>({
+export const revealedClozeGroups = StateField.define<DecorationSetMap>({
   create: (state) => {
     const parseResults = getClozeDecorationsState(state)
     const decSet = parseResults.clozeDecorationSet
@@ -73,6 +73,7 @@ const revealedClozeGroups = StateField.define<DecorationSetMap>({
 provide: f => EditorView.decorations.from(f)
 })
 
+export const clozePlugin = revealedClozeGroups
 
 class ClozeWidget extends WidgetType {
   private revealed: boolean;
@@ -85,7 +86,7 @@ class ClozeWidget extends WidgetType {
     this.clozeContent = content;
     this.groupId = groupId;
     this.revealed = revealed;
-    this.clozeP = `[${this.groupId}...]`
+    this.clozeP = `[... ${this.groupId} ...]`
   }
 
   // public toggle () {
@@ -174,10 +175,10 @@ const updateDecorationsState = (state: EditorState, clozeStateMap: Map<string, b
   return Decoration.set(widgets)
 }
 
-new EditorView({
-  doc: `const y = {{b::true}} // comment
-const x = {{b::Array(5).fill('e').every(e => e === 'e')}}
-const z = x {{c::&&}} y // z true`,
-  extensions: [basicSetup, javascript(), revealedClozeGroups, EditorView.editable.of(false)],
-  parent: document.getElementById("js-demo-1")!
-});
+// new EditorView({
+//   doc: `const y = {{b::true}} // comment
+// const x = {{b::Array(5).fill('e').every(e => e === 'e')}}
+// const z = x {{c::&&}} y // z true`,
+//   extensions: [basicSetup, javascript(), revealedClozeGroups, EditorView.editable.of(false)],
+//   parent: document.getElementById("js-demo-1")!
+// });

--- a/src/cloze-editor.ts
+++ b/src/cloze-editor.ts
@@ -1,47 +1,7 @@
-import { Facet, StateField, EditorState, StateEffect, StateEffectType } from "@codemirror/state";
-import { minimalSetup, basicSetup } from "codemirror";
-import { Decoration, EditorView, ViewUpdate, ViewPlugin, DecorationSet, WidgetType, keymap } from "@codemirror/view"
-import { javascript } from '@codemirror/lang-javascript';
+import { StateField, EditorState, StateEffect } from "@codemirror/state";
+import { Decoration, EditorView, DecorationSet, WidgetType } from "@codemirror/view"
 
-let clozeCounter = 1;
-
-const toggleClozeEffect = StateEffect.define<{ groupId: string, revealed: boolean }>(/*{
-  map: ({groupId, revealed}, change) => ({groupId: groupId, revealed: revealed})
-}*/)
-
-
-class ClozeGroupCollection {
-  public revealedMap: Map<string, boolean>
-  public clozeDecorationSet: DecorationSet
-  constructor(revealedMap: Map<string, boolean>, clozeDecorationSet: DecorationSet) {
-    this.revealedMap = revealedMap
-    this.clozeDecorationSet = clozeDecorationSet
-  }
-}
-
-// const revealedClozeGroups = StateField.define<ClozeGroupCollection>({
-//   create: (state) => {
-//     const parseResults = getClozeDecorationsState(state)
-//     const decSet = parseResults.clozeDecorationSet
-//     const map = new Map<string, boolean>(parseResults.clozePositions.map((x: { groupId: any; }) => [x.groupId, false]))
-//     return new ClozeGroupCollection(map, decSet)
-//   },
-//   update(value, tr) {
-//     value.clozeDecorationSet = value.clozeDecorationSet.map(tr.changes)
-//     // Update cloze state map
-//     let clozeStateMap = value.revealedMap;
-//     for (let e of tr.effects) if (e.is(toggleClozeEffect)) {
-//         const toggledGroupId = e.value.groupId;
-//         const toggleRevealed = e.value.revealed;
-//         clozeStateMap = clozeStateMap.set(toggledGroupId, clozeStateMap.has(toggledGroupId) ? !clozeStateMap.get(toggledGroupId) : toggleRevealed)
-//   }
-//   // Redraw all widgets
-//   const nextDecSet = updateDecorationsState(tr.state, value.revealedMap)
-//   const ret = new ClozeGroupCollection(clozeStateMap, nextDecSet)
-//   return ret
-// }, 
-// provide: f => EditorView.decorations.from(f)
-// })
+const toggleClozeEffect = StateEffect.define<{ groupId: string, revealed: boolean }>()
 
 interface DecorationSetMap extends DecorationSet {
   clozeStateMap: Map<string, boolean>;
@@ -58,29 +18,30 @@ export const revealedClozeGroups = StateField.define<DecorationSetMap>({
     value = (value.map(tr.changes)) as DecorationSetMap;
     // Update cloze state map
     if (tr.effects.length > 0) {
-    let clozeStateMap = value.clozeStateMap;
-    for (let e of tr.effects) if (e.is(toggleClozeEffect)) {
+      let clozeStateMap = value.clozeStateMap;
+      for (let e of tr.effects) if (e.is(toggleClozeEffect)) {
         const toggledGroupId = e.value.groupId;
         const toggleRevealed = e.value.revealed;
         clozeStateMap = clozeStateMap.set(toggledGroupId, clozeStateMap.has(toggledGroupId) ? !clozeStateMap.get(toggledGroupId) : toggleRevealed)
-  }
-  // Redraw all widgets
-  const nextDecSet = (updateDecorationsState(tr.state, clozeStateMap)) as DecorationSetMap
-  nextDecSet.clozeStateMap = clozeStateMap
-  return nextDecSet;}
-  return value;
-}, 
-provide: f => EditorView.decorations.from(f)
+      }
+      // Redraw all widgets
+      const nextDecSet = (updateDecorationsState(tr.state, clozeStateMap)) as DecorationSetMap
+      nextDecSet.clozeStateMap = clozeStateMap
+      return nextDecSet;
+    }
+    return value;
+  },
+  provide: f => EditorView.decorations.from(f)
 })
 
 export const clozePlugin = revealedClozeGroups
 
 class ClozeWidget extends WidgetType {
   private revealed: boolean;
-  private clozeContent: string; 
+  private clozeContent: string;
   public groupId: string;
   public clozeP;
-  
+
   constructor(readonly start: number, readonly end: number, content: string, groupId: string, revealed: boolean) {
     super();
     this.clozeContent = content;
@@ -89,25 +50,20 @@ class ClozeWidget extends WidgetType {
     this.clozeP = `[... ${this.groupId} ...]`
   }
 
-  // public toggle () {
-  //   this.revealed = !this.revealed
-  //   this.wrapPointer.innerText = this.revealed ? this.clozeContent : ClozeWidget.clozeP
-  // }
-
   toDOM(view: EditorView) {
     let wrap = document.createElement("span");
     wrap.setAttribute("aria-hidden", "true");
     wrap.className = "cb";
     wrap.style.display = "inline-flex";
     wrap.style.alignItems = "center";
-    wrap.style.border = "1px solid #ccc"; 
-    wrap.style.padding = "5px"; 
+    wrap.style.border = "1px solid #ccc";
+    wrap.style.padding = "5px";
     wrap.style.borderRadius = "5px";
     // wrap.style.minWidth = "48px"; // Minimum width for mobile hit target
     // wrap.style.minHeight = "48px"; // Minimum height for mobile hit target
     wrap.setAttribute("tabindex", "0");
     wrap.setAttribute("role", "button");
-  
+
     let cloze = wrap.appendChild(document.createElement("p"));
     cloze.innerText = this.revealed ? this.clozeContent : this.clozeP;
     cloze.style.margin = "0";
@@ -120,15 +76,14 @@ class ClozeWidget extends WidgetType {
         effects: toggleClozeEffect.of({ groupId: this.groupId, revealed: !this.revealed })
       });
     });
-      
+
     return wrap;
   }
 
-  ignoreEvent() { 
+  ignoreEvent() {
     return false;
   }
 }
-
 
 // groupId required
 const getClozePositions = (content: string): Array<{ from: number, to: number, groupId: string, content: string }> => {
@@ -144,30 +99,30 @@ const getClozePositions = (content: string): Array<{ from: number, to: number, g
   return clozePositions;
 };
 
-const getClozeDecorationsState = (state: EditorState, ): any => {
+const getClozeDecorationsState = (state: EditorState,): any => {
   const widgets: any[] = [];
   const clozePositions = getClozePositions(state.doc.toString());
   const docContent = state.doc.toString();
 
-  for (const { from, to, groupId, content } of clozePositions) {
+  for (const { from, to, groupId, } of clozePositions) {
     let deco = Decoration.replace({
-        widget: new ClozeWidget(from, to, docContent.slice(from + 2 + groupId.length + 4, to - 2), groupId, false),
-        side: 1
+      widget: new ClozeWidget(from, to, docContent.slice(from + 2 + groupId.length + 4, to - 2), groupId, false),
+      side: 1
     });
     widgets.push(deco.range(from, to));
   }
-  return { clozeDecorationSet: Decoration.set(widgets), clozePositions: clozePositions}
+  return { clozeDecorationSet: Decoration.set(widgets), clozePositions: clozePositions }
 };
 
-const updateDecorationsState = (state: EditorState, clozeStateMap: Map<string, boolean>, ): DecorationSet => {
+const updateDecorationsState = (state: EditorState, clozeStateMap: Map<string, boolean>,): DecorationSet => {
   const widgets: any[] = [];
   const clozePositions = getClozePositions(state.doc.toString());
   const docContent = state.doc.toString();
 
-  for (const { from, to, groupId, content } of clozePositions) {
+  for (const { from, to, groupId, } of clozePositions) {
     let deco = Decoration.replace({
-        widget: new ClozeWidget(from, to, docContent.slice(from + 2 + groupId.length + 2, to - 2), groupId, clozeStateMap.has(groupId) ? (clozeStateMap.get(groupId) === true) : false), // equality check with true to fix ts2345
-        side: 1
+      widget: new ClozeWidget(from, to, docContent.slice(from + 2 + groupId.length + 2, to - 2), groupId, clozeStateMap.has(groupId) ? (clozeStateMap.get(groupId) === true) : false), // equality check with true to fix ts2345
+      side: 1
     });
     widgets.push(deco.range(from, to));
   }

--- a/src/large-file-example.ts
+++ b/src/large-file-example.ts
@@ -1,14 +1,14 @@
 import { basicSetup } from "codemirror";
 import { EditorView } from "@codemirror/view"
 import { python } from '@codemirror/lang-python';
-import clozePlugin  from './cloze-editor';
+import { clozePlugin }  from './cloze-editor';
 
 new EditorView({
     doc: `
     # An example of a longer file from https://raw.githubusercontent.com/ytdl-org/youtube-dl/master/youtube_dl/aes.py.
-    # youtube-dl is a {{command-line}} program to download videos from YouTube.com and a few more sites. It requires the {{Python}} interpreter, version 2.6, 2.7, or 3.2+, and it is not platform specific. It should work on your Unix box, on Windows or on macOS. It is released {{to the public domain}}, which means you can modify it, redistribute it or use it however you like. 
+    # youtube-dl is a {{a::command-line}} program to download videos from YouTube.com and a few more sites. It requires the {{a::Python}} interpreter, version 2.6, 2.7, or 3.2+, and it is not platform specific. It should work on your Unix box, on Windows or on macOS. It is released {{a::to the public domain}}, which means you can modify it, redistribute it or use it however you like. 
     # 
-    # You can configure youtube-dl by placing any supported command line option to a configuration file. On {{Linux and macOS}}, the system wide configuration file is located at /etc/youtube-dl.conf and the user wide configuration file at ~/.config/youtube-dl/config. On {{Windows}}, the user wide configuration file locations are %APPDATA%\youtube-dl\config.txt or C:\Users\<user name>\youtube-dl.conf. Note that by default configuration file may not exist so you may need to create it yourself.
+    # You can configure youtube-dl by placing any supported command line option to a configuration file. On {{a::Linux and macOS}}, the system wide configuration file is located at /etc/youtube-dl.conf and the user wide configuration file at ~/.config/youtube-dl/config. On {{a::Windows}}, the user wide configuration file locations are %APPDATA%\youtube-dl\config.txt or C:\Users\<user name>\youtube-dl.conf. Note that by default configuration file may not exist so you may need to create it yourself.
     from __future__ import unicode_literals
 
     from math import ceil
@@ -27,8 +27,8 @@ new EditorView({
         @returns {int[]}           padding data
         """
     
-        remaining_length = {{BLOCK_SIZE_BYTES}} - {{len(data)}} % {{BLOCK_SIZE_BYTES}}
-        return {{data + [remaining_length] * remaining_length}}
+        remaining_length = {{a::BLOCK_SIZE_BYTES}} - {{a::len(data)}} % {{a::BLOCK_SIZE_BYTES}}
+        return {{a::data + [remaining_length] * remaining_length}}
     
     
     def aes_ctr_decrypt(data, key, counter):
@@ -41,17 +41,17 @@ new EditorView({
                                    returns the next counter block
         @returns {int[]}           decrypted data
         """
-        expanded_key = {{key_expansion(key)}}
+        expanded_key = {{a::key_expansion(key)}}
         block_count = int(ceil(float(len(data)) / BLOCK_SIZE_BYTES))
     
         decrypted_data = []
         for i in range(block_count):
             counter_block = counter.next_value()
-            block = data[{{i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
+            block = data[{{a::i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
             block += [0] * (BLOCK_SIZE_BYTES - len(block))
     
             cipher_counter_block = aes_encrypt(counter_block, expanded_key)
-            decrypted_data += {{xor}}(block, cipher_counter_block)
+            decrypted_data += {{a::xor}}(block, cipher_counter_block)
         decrypted_data = decrypted_data[:len(data)]
     
         return decrypted_data
@@ -67,15 +67,15 @@ new EditorView({
         @returns {int[]}           decrypted data
         """
         expanded_key = key_expansion(key)
-        block_count = int({{ceil(float(len(data)) / BLOCK_SIZE_BYTES)}})
+        block_count = int({{a::ceil(float(len(data)) / BLOCK_SIZE_BYTES)}})
     
         decrypted_data = []
         previous_cipher_block = iv
         for i in range(block_count):
-            block = data[{{i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
+            block = data[{{a::i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
             block += [0] * (BLOCK_SIZE_BYTES - len(block))
     
-            decrypted_block = aes_decrypt({{block, expanded_key}})
+            decrypted_block = aes_decrypt({{a::block, expanded_key}})
             decrypted_data += xor(decrypted_block, previous_cipher_block)
             previous_cipher_block = block
         decrypted_data = decrypted_data[:len(data)]
@@ -100,10 +100,10 @@ new EditorView({
         for i in range(block_count):
             block = data[i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES]
             block = pkcs7_padding(block)
-            mixed_block = xor({{block, previous_cipher_block}})
+            mixed_block = xor({{a::block, previous_cipher_block}})
     
             encrypted_block = aes_encrypt(mixed_block, expanded_key)
-            encrypted_data += {{encrypted_block}}
+            encrypted_data += {{a::encrypted_block}}
     
             previous_cipher_block = encrypted_block
     
@@ -379,14 +379,14 @@ new EditorView({
         data_shifted = []
         for column in range(4):
             for row in range(4):
-                data_shifted.append(data[{{((column + row) & 0b11) * 4 + row}}])
+                data_shifted.append(data[{{a::((column + row) & 0b11) * 4 + row}}])
         return data_shifted
     
     
     def shift_rows_inv(data):
         data_shifted = []
-        {{for column in range(4):}}
-            {{for row in range(4):}}
+        {{a::for column in range(4):}}
+            {{a::for row in range(4):}}
                 data_shifted.append(data[((column - row) & 0b11) * 4 + row])
         return data_shifted
     
@@ -397,8 +397,8 @@ new EditorView({
             if data[i] == 255:
                 data[i] = 0
             else:
-                {{data[i] = data[i] + 1}}
-                {{break}}
+                {{a::data[i] = data[i] + 1}}
+                {{a::break}}
         return data
     
     

--- a/src/large-file-example.ts
+++ b/src/large-file-example.ts
@@ -6,9 +6,9 @@ import { clozePlugin }  from './cloze-editor';
 new EditorView({
     doc: `
     # An example of a longer file from https://raw.githubusercontent.com/ytdl-org/youtube-dl/master/youtube_dl/aes.py.
-    # youtube-dl is a {{a::command-line}} program to download videos from YouTube.com and a few more sites. It requires the {{a::Python}} interpreter, version 2.6, 2.7, or 3.2+, and it is not platform specific. It should work on your Unix box, on Windows or on macOS. It is released {{a::to the public domain}}, which means you can modify it, redistribute it or use it however you like. 
+    # youtube-dl is a {{q::command-line}} program to download videos from YouTube.com and a few more sites. It requires the {{w::Python}} interpreter, version 2.6, 2.7, or 3.2+, and it is not platform specific. It should work on your Unix box, on Windows or on macOS. It is released {{this_is_a_longer_label_how_does_it_look::to the public domain}}, which means you can modify it, redistribute it or use it however you like. 
     # 
-    # You can configure youtube-dl by placing any supported command line option to a configuration file. On {{a::Linux and macOS}}, the system wide configuration file is located at /etc/youtube-dl.conf and the user wide configuration file at ~/.config/youtube-dl/config. On {{a::Windows}}, the user wide configuration file locations are %APPDATA%\youtube-dl\config.txt or C:\Users\<user name>\youtube-dl.conf. Note that by default configuration file may not exist so you may need to create it yourself.
+    # You can configure youtube-dl by placing any supported command line option to a configuration file. On {{e::Linux and macOS}}, the system wide configuration file is located at /etc/youtube-dl.conf and the user wide configuration file at ~/.config/youtube-dl/config. On {{e::Windows}}, the user wide configuration file locations are %APPDATA%\youtube-dl\config.txt or C:\Users\<user name>\youtube-dl.conf. Note that by default configuration file may not exist so you may need to create it yourself.
     from __future__ import unicode_literals
 
     from math import ceil
@@ -27,8 +27,8 @@ new EditorView({
         @returns {int[]}           padding data
         """
     
-        remaining_length = {{a::BLOCK_SIZE_BYTES}} - {{a::len(data)}} % {{a::BLOCK_SIZE_BYTES}}
-        return {{a::data + [remaining_length] * remaining_length}}
+        remaining_length = {{r::BLOCK_SIZE_BYTES}} - {{r::len(data)}} % {{r::BLOCK_SIZE_BYTES}}
+        return {{t::data + [remaining_length] * remaining_length}}
     
     
     def aes_ctr_decrypt(data, key, counter):
@@ -41,17 +41,17 @@ new EditorView({
                                    returns the next counter block
         @returns {int[]}           decrypted data
         """
-        expanded_key = {{a::key_expansion(key)}}
+        expanded_key = {{y::key_expansion(key)}}
         block_count = int(ceil(float(len(data)) / BLOCK_SIZE_BYTES))
     
         decrypted_data = []
         for i in range(block_count):
             counter_block = counter.next_value()
-            block = data[{{a::i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
+            block = data[{{u::i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
             block += [0] * (BLOCK_SIZE_BYTES - len(block))
     
             cipher_counter_block = aes_encrypt(counter_block, expanded_key)
-            decrypted_data += {{a::xor}}(block, cipher_counter_block)
+            decrypted_data += {{i::xor}}(block, cipher_counter_block)
         decrypted_data = decrypted_data[:len(data)]
     
         return decrypted_data
@@ -67,15 +67,15 @@ new EditorView({
         @returns {int[]}           decrypted data
         """
         expanded_key = key_expansion(key)
-        block_count = int({{a::ceil(float(len(data)) / BLOCK_SIZE_BYTES)}})
+        block_count = int({{o::ceil(float(len(data)) / BLOCK_SIZE_BYTES)}})
     
         decrypted_data = []
         previous_cipher_block = iv
         for i in range(block_count):
-            block = data[{{a::i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
+            block = data[{{p::i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES}}]
             block += [0] * (BLOCK_SIZE_BYTES - len(block))
     
-            decrypted_block = aes_decrypt({{a::block, expanded_key}})
+            decrypted_block = aes_decrypt({{s::block, expanded_key}})
             decrypted_data += xor(decrypted_block, previous_cipher_block)
             previous_cipher_block = block
         decrypted_data = decrypted_data[:len(data)]
@@ -100,10 +100,10 @@ new EditorView({
         for i in range(block_count):
             block = data[i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES]
             block = pkcs7_padding(block)
-            mixed_block = xor({{a::block, previous_cipher_block}})
+            mixed_block = xor({{d::block, previous_cipher_block}})
     
             encrypted_block = aes_encrypt(mixed_block, expanded_key)
-            encrypted_data += {{a::encrypted_block}}
+            encrypted_data += {{d::encrypted_block}}
     
             previous_cipher_block = encrypted_block
     
@@ -379,14 +379,14 @@ new EditorView({
         data_shifted = []
         for column in range(4):
             for row in range(4):
-                data_shifted.append(data[{{a::((column + row) & 0b11) * 4 + row}}])
+                data_shifted.append(data[{{f::((column + row) & 0b11) * 4 + row}}])
         return data_shifted
     
     
     def shift_rows_inv(data):
         data_shifted = []
-        {{a::for column in range(4):}}
-            {{a::for row in range(4):}}
+        {{g::for column in range(4):}}
+            {{g::for row in range(4):}}
                 data_shifted.append(data[((column - row) & 0b11) * 4 + row])
         return data_shifted
     
@@ -397,8 +397,8 @@ new EditorView({
             if data[i] == 255:
                 data[i] = 0
             else:
-                {{a::data[i] = data[i] + 1}}
-                {{a::break}}
+                {{g::data[i] = data[i] + 1}}
+                {{g::break}}
         return data
     
     


### PR DESCRIPTION
# Overview
We introduce a concept of the "cloze group", which is essentially a set of clozes. Each cloze belongs to exactly one group. When a user interacts with any cloze within a group, all clozes in that same group will simultaneously reveal their content, thus enhancing the information coherence for the user. 

Previously, each cloze operated in isolation, essentially behaving as though it was in its own group. In terms of the cloze deletion language, cloze deletions are now given as `{{group_id::hidden_text}}`, where group_id is an identifier string for the group.

# Details
We changed the design of the cloze extension in 2 ways:
1. The cloze functionality is now implemented using a CodeMirror 6 `StateField` (namely `revealedClozeGroups`) and `StateEffect` (namely `toggleClozeEffect`), as opposed to prior use of a `Plugin` and maintaining the state in each individual `ClozeWidget`. 
- Using `StateField` allows interaction with one `ClozeWidget` to affect other `ClozeWidgets`, specifically those in the same group.
- These changes also make it possible to create multi-line Widgets, but further work is required to make multi-line Widgets usable.

2. We require every cloze to include a `group_id`.
- Inclusion of a `group_id` enables us to parse the document upon every refresh to identify the location of each individual cloze. We maintain a map from each `groupId` to the state of the group.